### PR TITLE
As a team, we have moved from the old org (SiCKRAGETV) to a new org (…

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@ SickRage Server qpkg for QNAP
 
 Steps required to build the package on a QNAP TVS:
 
-    git clone https://github.com/eXodus1440/SickRage_QPKG.git SickRage
-    cd SickRage/shared
+    git clone https://github.com/eXodus1440/SickRage_QPKG.git SickChill
+    cd SickChill/shared
 
-    git clone https://github.com/SickRage/SickRage.git 
-    mv SickRage/* SickRage/.* .
-    rm -rf SickRage
+    git clone https://github.com/SickChill/SickChill.git 
+    mv SickChill/* SickChill/.* .
+    rm -rf SickChill
 
     cd ..
     qbuild --exclude solaris --exclude *.cmd

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Steps required to build the package on a QNAP TVS:
     git clone https://github.com/eXodus1440/SickRage_QPKG.git SickRage
     cd SickRage/shared
 
-    git clone https://github.com/SiCKRAGETV/SickRage.git 
+    git clone https://github.com/SickRage/SickRage.git 
     mv SickRage/* SickRage/.* .
     rm -rf SickRage
 


### PR DESCRIPTION
…SickRage), only leaving echelon behind.

New org is nearing 2k commits ahead of the old one and is much more stable and maintained,
as well as a much larger user base as users have opted to move with the team.
For questions, we are on freenode in #sickrage-issues
